### PR TITLE
fix: skip function with variadics

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -102,6 +102,10 @@ func (c *processor) process(n ast.Node) (*Result, error) {
 				}
 			}
 
+			if len(paramTypes) != len(x.Args) {
+				return &Result{}, nil
+			}
+
 			for i, arg := range x.Args {
 				a, ok := arg.(*ast.SelectorExpr)
 				if !ok {

--- a/testdata/proto/tassert.go
+++ b/testdata/proto/tassert.go
@@ -1,0 +1,12 @@
+package proto
+
+import (
+	"net/http"
+	"testing"
+)
+
+func _(tb testing.TB, client *http.Client, req *http.Request, statusCode int) {
+	Errorf(tb, false, "expected %v status code, got %v %v", statusCode, req.URL, client.Transport)
+}
+
+func Errorf(tb testing.TB, cond bool, format string, args ...any) {}


### PR DESCRIPTION
With a variadic, the `decl.Type.Params` contains an `*ast.Ellipsis` and not a type by variadic values.

fixes #18
